### PR TITLE
fixed a member initializer to conform to the C++11 specification

### DIFF
--- a/official/raceState.cpp
+++ b/official/raceState.cpp
@@ -10,9 +10,9 @@ RaceState::RaceState(RaceCourse &course,
 		     string &player0, string &name0, FILE* logFile0,
 		     string &player1, string &name1, FILE* logFile1):
   course(&course),
-  players({
+  players{
       Player(player0, course, course.startX[0], name0, logFile0),
-	Player(player1, course, course.startX[1], name1, logFile1)}) {
+	Player(player1, course, course.startX[1], name1, logFile1)} {
   goalTime[0] = goalTime[1] = 2*course.stepLimit;
   goaled[0] = goaled[1] = false;
 }


### PR DESCRIPTION
remove a pair of parentheses from a member initialization. In the C++11 specification, extra parentheses indicate the value-initialization instead of the list-initialization, if the GNU extension [-Wgnu-array-member-paren-init] is not specified.

constructor の中のメンバー初期化で，リストで初期化する際に余計な括弧が含まれていました．これは，gcc のextension では許容されますが，llvmベースのmacのC++コンパイラではエラーになります．余計な括弧を取り除くことを求めるPRです．