### PR TITLE
changed variable names in Makefile to adapt to the GNU make standard

### DIFF
--- a/official/Makefile
+++ b/official/Makefile
@@ -1,5 +1,5 @@
-CPPFLAGS= -pthread -std=c++11 -g -Wall
-CPP= c++
+CXXFLAGS= -pthread -std=c++11 -g -Wall
+CXX= c++
 
 OBJECTS= main.o course.o raceState.o player.o
 SOURCES= *.cpp *.hpp
@@ -12,13 +12,13 @@ tags: ${SOURCES}
 	etags $^
 
 ${TARGET}: ${OBJECTS}
-	${CPP} ${CPPFLAGS} -o $@ $^
+	${CXX} ${CXXFLAGS} -o $@ $^
 
 -include ${OBJECTS:.o=.d}
 
 %.o: %.cpp
-	${CPP} -c ${CPPFLAGS} $*.cpp -o $*.o
-	${CPP} -MM ${CPPFLAGS} $*.cpp > $*.d
+	${CXX} -c ${CXXFLAGS} $*.cpp -o $*.o
+	${CXX} -MM ${CXXFLAGS} $*.cpp > $*.d
 
 clean:
 	rm -f TAGS

--- a/player/Makefile
+++ b/player/Makefile
@@ -1,5 +1,5 @@
-CPPFLAGS= -pthread -std=c++11 -g -Wall
-CPP= c++
+CXXFLAGS= -pthread -std=c++11 -g -Wall
+CXX= c++
 
 OBJECTS= greedy.o raceState.o
 
@@ -8,13 +8,13 @@ TARGET= greedy
 all: ${TARGET}
 
 ${TARGET}: ${OBJECTS}
-	${CPP} ${CPPFLAGS} -o $@ $^
+	${CXX} ${CXXFLAGS} -o $@ $^
 
 -include ${OBJECTS:.o=.d}
 
 %.o: %.cpp
-	${CPP} -c ${CPPFLAGS} $*.cpp -o $*.o
-	${CPP} -MM ${CPPFLAGS} $*.cpp > $*.d
+	${CXX} -c ${CXXFLAGS} $*.cpp -o $*.o
+	${CXX} -MM ${CXXFLAGS} $*.cpp > $*.d
 
 clean:
 	rm -f *.o *.d


### PR DESCRIPTION
Makefile中でCPP, CPPFLAGSという変数名がc++コンパイラのコマンド名，コマンドラインオプションの意味で使われていた．しかし，GNU make のVariables Used by Implicit Rules ( https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html ) ではこの名前は，

```
CPP
Program for running the C preprocessor, with results to standard output; default ‘$(CC) -E’.
CPPFLAGS
Extra flags to give to the C preprocessor and programs that use it (the C and Fortran compilers).

```
のようにC preprocessor のコマンド名，コマンドラインオプションを示す変数に使われている．混乱の元なので，
```
CXX
Program for compiling C++ programs; default ‘g++’.
CXXFLAGS
Extra flags to give to the C++ compiler.
```
に置き換える．

