### PR TITLE
pass environment variables

### DIFF
--- a/official/main.cpp
+++ b/official/main.cpp
@@ -1,6 +1,6 @@
 #include "raceState.hpp"
 
-int main(int argc, char *argv[]) {
+int main(int argc, char *argv[], char *envp[]) {
   if (argc < 6 || 8 < argc ) {
     cerr << "Usage: " << argv[0]
 	 << " <course file> <player0> <name0> <player1> <name1> "
@@ -16,7 +16,7 @@ int main(int argc, char *argv[]) {
   string name1 = argv[5];
   FILE* logFile0 = argc > 6 ? fopen(argv[6], "w") : nullptr;
   FILE* logFile1 = argc > 7 ? fopen(argv[7], "w") : nullptr;
-  RaceState state(course, player0, name0, logFile0, player1, name1, logFile1);
+  RaceState state(course, player0, name0, logFile0, player1, name1, logFile1, envp);
   for (int c = 0; c != course.stepLimit && !state.playOneStep(c); c++)
     ;
   for (int p = 0; p != 2; p++) {

--- a/official/player.cpp
+++ b/official/player.cpp
@@ -40,7 +40,7 @@ void flushToAI(FILE* toAI, FILE* logOutput) {
 
 
 Player::Player(string command, const RaceCourse &course, int xpos,
-	       string name, FILE* logFile):
+	       string name, FILE* logFile, char *envp[]):
   name(name), logOutput(logFile), position(Point(xpos, 0)), velocity(0, 0),
   timeLeft(course.thinkTime) {
   int infoPipe[2];
@@ -59,7 +59,6 @@ Player::Player(string command, const RaceCourse &course, int xpos,
     close(respPipe[0]);
     char *cmd = strcpy(new char[command.size()+1], command.c_str());
     char *const argv[] = { cmd, nullptr };
-    char *const envp[] = { nullptr };
     execve(cmd, argv, envp);
   } else {
     toAI = fdopen(infoPipe[1], "w");

--- a/official/player.hpp
+++ b/official/player.hpp
@@ -12,7 +12,7 @@ struct Player {
   IntVec velocity;
   int timeLeft;
   Player(string command, const RaceCourse &course,
-	 int xpos, string name, FILE *logFile);
+	 int xpos, string name, FILE *logFile, char *envp[]);
   IntVec play(int c, Player &op, RaceCourse &course);
   void terminate();
 };

--- a/official/raceState.cpp
+++ b/official/raceState.cpp
@@ -8,11 +8,11 @@ StepRecord::StepRecord(int step, PlayerState bfr, IntVec accel,
 
 RaceState::RaceState(RaceCourse &course,
 		     string &player0, string &name0, FILE* logFile0,
-		     string &player1, string &name1, FILE* logFile1):
+		     string &player1, string &name1, FILE* logFile1, char *envp[]):
   course(&course),
   players({
-      Player(player0, course, course.startX[0], name0, logFile0),
-	Player(player1, course, course.startX[1], name1, logFile1)}) {
+      Player(player0, course, course.startX[0], name0, logFile0, envp),
+	Player(player1, course, course.startX[1], name1, logFile1, envp)}) {
   goalTime[0] = goalTime[1] = 2*course.stepLimit;
   goaled[0] = goaled[1] = false;
 }

--- a/official/raceState.hpp
+++ b/official/raceState.hpp
@@ -42,6 +42,6 @@ struct RaceState {
   list<StepRecord> records[2];
   RaceState(RaceCourse &course,
 	    string& player0, string &name0, FILE* logFile0,
-	    string &player1, string &name1, FILE* logFile1);
+	    string &player1, string &name1, FILE* logFile1, char *envp[]);
   bool playOneStep(int c);
 };


### PR DESCRIPTION
現在の official/player.cpp は execve する際のenvp として，{ nullptr } を渡しています．これは，一般的には安全性という意味では良い(たとえばsetuidしているプログラムの起動など)のですが，スクリプト言語で

`
#/usr/bin/env python
`
などとした時などに，環境変数が引き継がれないために問題が生じることがあります．

そこで，mainのenvpをexecve に渡すように変更する内容の PR になります．