### PR TITLE
Avoid negative y-coordinate

### DIFF
--- a/official/raceState.cpp
+++ b/official/raceState.cpp
@@ -31,7 +31,7 @@ bool RaceState::playOneStep(int c) {
       nextPosition[p] = players[p].position + nextVelocity[p];
       move[p] = LineSegment(players[p].position, nextPosition[p]);
       if (nextPosition[p].x < 0 || course->width <= nextPosition[p].x ||
-	  course->collides(move[p])) {
+	  nextPosition[p].y < 0 || course->collides(move[p])) {
 	res[p] = STOPPED;
       }
     }


### PR DESCRIPTION
スタート直後に
`
0 -1
`
とプレイヤが出力すると，予定位置のy座標が-1 となり，コースアウトになる．コースアウトなので，元の座標に留まるはずである．しかし，元のプログラムはnextPositionのy座標をチェックしていないので，segmentation faultで落ちてしまう(環境によっては落ちないかもしれないが，macOS環境では落ちた)．