### PR TITLE
add option for stderr, Docker

### DIFF
--- a/official/Makefile
+++ b/official/Makefile
@@ -1,5 +1,5 @@
 CXXFLAGS= -pthread -std=c++11 -W -Wall -g -ggdb
-AM_LDFLAGS= -lboost_system$(BOOST_LIB_SUFFIX) -lboost_filesystem$(BOOST_LIB_SUFFIX)
+AM_LDFLAGS= -lboost_system$(BOOST_LIB_SUFFIX) -lboost_filesystem$(BOOST_LIB_SUFFIX) -lboost_program_options$(BOOST_LIB_SUFFIX)
 CXX= c++
 
 OBJECTS= main.o course.o raceState.o player.o

--- a/official/main.cpp
+++ b/official/main.cpp
@@ -1,22 +1,68 @@
 #include "raceState.hpp"
 
+#include <boost/program_options.hpp>
+
 int main(int argc, char *argv[]) {
-  if (argc < 6 || 8 < argc ) {
-    cerr << "Usage: " << argv[0]
-	 << " <course file> <player0> <name0> <player1> <name1> "
-	 << "[<logFile0> [<logFile1>]]"
-	 << endl;
+  boost::program_options::options_description desc("<option>");
+  desc.add_options()
+    ("stdinLogFile0", boost::program_options::value<std::string>()->value_name("<filename>"), "logfile name for player0 standard input")
+    ("stdinLogFile1", boost::program_options::value<std::string>()->value_name("<filename>"), "logfile name for player1 standard input")
+    ("stderrLogFile0", boost::program_options::value<std::string>()->value_name("<filename>"), "logfile name for player0 standard error output")
+    ("stderrLogFile1", boost::program_options::value<std::string>()->value_name("<filename>"), "logfile name for player1 standard error output")
+    ("pauseP0", boost::program_options::value<std::string>()->value_name("<command>"), "pause command for player0")
+    ("resumeP0", boost::program_options::value<std::string>()->value_name("<command>"), "resume command for player0")
+    ("pauseP1", boost::program_options::value<std::string>()->value_name("<command>"), "pause command for player1")
+    ("resumeP1", boost::program_options::value<std::string>()->value_name("<command>"), "resume command for player1")
+    ("help,h", "produce help");
+  boost::program_options::variables_map vm;
+  std::vector<std::string> unnamed_args;
+  auto help_message = [&] {
+    cerr << "Usage: " << argv[0] << " <course file> <player0> <name0> <player1> <name1> [<option>...]" << endl;
+    cerr << endl;
+    cerr << desc << endl;
+  };
+  try {
+    const auto parsing_result = boost::program_options::parse_command_line(argc, argv, desc);
+    boost::program_options::store(parsing_result, vm);
+    boost::program_options::notify(vm);
+    unnamed_args = boost::program_options::collect_unrecognized(parsing_result.options, boost::program_options::include_positional);
+  } catch (std::exception) {
+    cerr << "invalid command line arguments" << endl;;
+    help_message();
     return 1;
   }
-  ifstream in(argv[1]);
+  if (vm.count("help") || unnamed_args.size() != 5) {
+    help_message();
+    return 1;
+  }
+  ifstream in(unnamed_args[0]);
   RaceCourse course(in);
-  string player0 = argv[2];
-  string name0 = argv[3];
-  string player1 = argv[4];
-  string name1 = argv[5];
-  FILE* logFile0 = argc > 6 ? fopen(argv[6], "w") : nullptr;
-  FILE* logFile1 = argc > 7 ? fopen(argv[7], "w") : nullptr;
-  RaceState state(course, player0, name0, logFile0, player1, name1, logFile1);
+  string player0 = unnamed_args[1];
+  string name0 = unnamed_args[2];
+  string player1 = unnamed_args[3];
+  string name1 = unnamed_args[4];
+  std::array<Option, 2> options;
+  auto take_ofstream = [](const boost::program_options::variables_map& vm, const std::string& target) -> std::shared_ptr<std::ofstream> {
+    if (vm.count(target)) {
+      return std::shared_ptr<std::ofstream>(new std::ofstream(vm[target].as<std::string>()));
+    } else {
+      return nullptr;
+    }
+  };
+  auto take_command = [](const boost::program_options::variables_map& vm, const std::string& target) -> boost::optional<std::string> {
+    if (vm.count(target)) {
+      return vm[target].as<std::string>();
+    } else {
+      return boost::none;
+    }
+  };
+  for (int i = 0; i < 2; ++i) {
+    options[i].stdinLogStream = take_ofstream(vm, "stdinLogFile" + std::to_string(i));
+    options[i].stderrLogStream = take_ofstream(vm, "stderrLogFile" + std::to_string(i));
+    options[i].pauseCommand = take_command(vm, "pauseP" + std::to_string(i));
+    options[i].resumeCommand = take_command(vm, "resumeP" + std::to_string(i));
+  }
+  RaceState state(course, player0, name0, player1, name1, options);
   for (int c = 0; c != course.stepLimit && !state.playOneStep(c); c++)
     ;
   for (int p = 0; p != 2; p++) {

--- a/official/player.cpp
+++ b/official/player.cpp
@@ -5,14 +5,19 @@
 #include <future>
 #include <thread>
 #include <chrono>
+#include <mutex>
 #include <boost/optional.hpp>
 
 #include "course.hpp"
 #include "player.hpp"
 
-static boost::optional<int> readInt(std::unique_ptr<boost::process::ipstream>& in) {
+using Message = std::pair<boost::optional<int>, std::vector<std::string>>;
+
+static Message readInt(std::unique_ptr<boost::process::ipstream>& in) {
+  std::vector<string> msg;
   if (!in) {
-    return boost::none;
+    msg.push_back("input stream is closed");
+    return std::make_pair(boost::none, msg);
   }
   int num;
   std::string str;
@@ -20,137 +25,276 @@ static boost::optional<int> readInt(std::unique_ptr<boost::process::ipstream>& i
   try {
     num = std::stoi(str);
   } catch (const std::invalid_argument& e) {
-    std::cerr << "input invalid argument from AI : \"" << str << "\""<< std::endl;
-    std::cerr << e.what() << std::endl;
-    return boost::none;
+    std::string clipped;
+    if (str.length() >= 100) {
+      str = str.substr(0, 100) + "...";
+      clipped = "(clipped)";
+    }
+    msg.push_back("input invalid argument from AI : \"" + str + "\"" + clipped);
+    msg.push_back("what : " + std::string(e.what()));
+    return std::make_pair(boost::none, msg);
   } catch (const std::out_of_range& e) {
-    std::cerr << "input out of int range value from AI : \"" << str << "\"" << std::endl;
-    std::cerr << e.what() << std::endl;
-    return boost::none;
+    std::string clipped;
+    if (str.length() >= 100) {
+      str = str.substr(0, 100) + "...";
+      clipped = "(clipped)";
+    }
+    msg.push_back("input out of int range value from AI : \"" + str + "\"" + clipped);
+    msg.push_back("what : " + std::string(e.what()));
+    return std::make_pair(boost::none, msg);
   }
-  return num;
+  return std::make_pair(boost::optional<int>(num), msg);
 }
 
-static void handShake(std::unique_ptr<boost::process::ipstream> in, std::promise<std::pair<std::unique_ptr<boost::process::ipstream>, boost::optional<int>>> p)
+static void handShake(std::unique_ptr<boost::process::ipstream> in, std::promise<std::pair<std::unique_ptr<boost::process::ipstream>, Message>> p)
 {
   auto ans = readInt(in);
   p.set_value(make_pair(std::move(in), ans));
 }
 
-void sendToAI(std::unique_ptr<boost::process::opstream>&  toAI, FILE* logOutput, const char *fmt, int value) {
+void sendToAI(std::unique_ptr<boost::process::opstream>&  toAI, std::shared_ptr<std::ofstream> stdinLogStream, const char *fmt, int value) {
   int n = std::snprintf(nullptr, 0, fmt, value);
   auto cstr = new std::unique_ptr<char[]>(new char[n + 2]);
   std::snprintf(cstr->get(), n + 1, fmt, value);
   std::string str(cstr->get());
   *toAI << str;
-  if (logOutput != nullptr) fprintf(logOutput, fmt, value);
+  if (stdinLogStream.get() != nullptr) {
+    *stdinLogStream << str;
+  }
 }
 
-void flushToAI(std::unique_ptr<boost::process::opstream>& toAI, FILE* logOutput) {
+void flushToAI(std::unique_ptr<boost::process::opstream>& toAI, std::shared_ptr<std::ofstream> stdinLogStream) {
   toAI->flush();
-  if (logOutput != nullptr) fflush(logOutput);
+  if (stdinLogStream.get() != nullptr) stdinLogStream->flush();
 }
 
+static void logging(std::promise<void> promise, std::unique_ptr<std::istream> input, std::shared_ptr<std::ostream> output, int MAX_SIZE) {
+  if (output) {
+    int size = 0;
+    for (; MAX_SIZE == -1 || size < MAX_SIZE; ++size) {
+      char c;
+      if (input->get(c)) {
+        std::lock_guard<std::mutex> lock(mutex);
+        *output << c;
+      } else {
+        break;
+      }
+    }
+    if (MAX_SIZE != -1 && size >= MAX_SIZE) {
+      *output << std::endl;
+      *output << "[system] stderr output have reached the limit(MAX_SIZE=" << MAX_SIZE << " bytes)" << std::endl;
+    }
+  }
+  promise.set_value();
+}
+
+Logger::Logger(std::unique_ptr<std::istream> input, std::shared_ptr<std::ostream> output, int MAX_SIZE = -1) {
+  std::promise<void> promise;
+  future = promise.get_future();
+  thread = std::thread(logging, std::move(promise), std::move(input), output, MAX_SIZE);
+}
+
+Logger::~Logger() {
+  mutex.unlock();
+  future.wait_for(std::chrono::milliseconds(100));
+  thread.join();
+}
 
 Player::Player(string command, const RaceCourse &course, int xpos,
-         string name, FILE* logFile):
-  name(name), logOutput(logFile), position(Point(xpos, 0)), velocity(0, 0),
-  timeLeft(course.thinkTime), status(Status::VALID) {
+         string name, const Option &opt):
+  name(name), position(Point(xpos, 0)), velocity(0, 0),
+  timeLeft(course.thinkTime), status(Status::VALID),
+  stdinLogStream(opt.stdinLogStream), stderrLogStream(opt.stderrLogStream),
+  pauseCommand(opt.pauseCommand), resumeCommand(opt.resumeCommand) {
   auto env = boost::this_process::environment();
+  std::error_code error_code_child;
+  std::unique_ptr<boost::process::ipstream> stderrFromAI(new boost::process::ipstream);
   toAI = std::unique_ptr<boost::process::opstream>(new boost::process::opstream);
   fromAI = std::unique_ptr<boost::process::ipstream>(new boost::process::ipstream);
   child = std::unique_ptr<boost::process::child>(new boost::process::child(
     command,
     boost::process::std_out > *fromAI,
-    boost::process::std_err > stderr,
+    boost::process::std_err > *stderrFromAI,
     boost::process::std_in < *toAI,
-    env
+    env,
+    error_code_child
   ));
-  sendToAI(toAI, logOutput, "%d\n", course.thinkTime);
-  sendToAI(toAI, logOutput, "%d\n", course.stepLimit);
-  sendToAI(toAI, logOutput, "%d ", course.width);
-  sendToAI(toAI, logOutput, "%d\n", course.length);
-  sendToAI(toAI, logOutput, "%d\n", course.vision);
-  flushToAI(toAI, logOutput);
-  std::promise<std::pair<std::unique_ptr<boost::process::ipstream>, boost::optional<int>>> promise;
-  std::future<std::pair<std::unique_ptr<boost::process::ipstream>, boost::optional<int>>> future = promise.get_future();
+  if (stderrLogStream) {
+    *stderrLogStream << "[system] Try : hand shake" << endl;
+  }
+  stderrLogger = std::unique_ptr<Logger>(new Logger(std::move(stderrFromAI), stderrLogStream, 1 << 15));
+  sendToAI(toAI, stdinLogStream, "%d\n", course.thinkTime);
+  sendToAI(toAI, stdinLogStream, "%d\n", course.stepLimit);
+  sendToAI(toAI, stdinLogStream, "%d ", course.width);
+  sendToAI(toAI, stdinLogStream, "%d\n", course.length);
+  sendToAI(toAI, stdinLogStream, "%d\n", course.vision);
+  flushToAI(toAI, stdinLogStream);
+  std::promise<std::pair<std::unique_ptr<boost::process::ipstream>, Message>> promise;
+  std::future<std::pair<std::unique_ptr<boost::process::ipstream>, Message>> future = promise.get_future();
   std::chrono::milliseconds remain(timeLeft);
-  std::chrono::system_clock::time_point start = std::chrono::system_clock::now();
   std::thread thread(handShake, std::move(fromAI), std::move(promise));
+  std::chrono::system_clock::time_point start = std::chrono::system_clock::now();
   std::future_status result = future.wait_for(remain);
   std::chrono::system_clock::time_point end = std::chrono::system_clock::now();
-  timeLeft -= std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+  auto timeUsed = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+  timeLeft -= timeUsed;
   thread.join();
+  stderrLogger->mutex.lock();
+  if (stderrLogStream) {
+    *stderrLogStream << "[system] spend time: " << timeUsed << ", remain: " << timeLeft << endl;
+  }
+  if (pauseCommand) {
+    std::error_code ec;
+    int result = boost::process::system(pauseCommand.get(), ec);
+    std::cerr << __FILE__ << ":" << __LINE__ << ": [pause] (" << name << ") return code : " << result << ", error value : " << ec.value() << ", error message : " << ec.message() << std::endl;
+  }
   if (result == std::future_status::timeout) {
     status = Status::TIMEOUT;
-    std::cerr << "player : " << name << " has been timeouted" << std::endl;
+    std::cerr << "player : \"" << name << "\" has been timeouted" << std::endl;
+    if (stderrLogStream) {
+      *stderrLogStream << "your AI : \"" << name << "\" has been timeouted" << std::endl;
+    }
     return;
   }
   auto ret = future.get();
   fromAI = std::move(ret.first);
-  auto ans = ret.second;
+  auto ans = ret.second.first;
+  for (const auto& line : ret.second.second) {
+    std::cerr << line << std::endl;
+    if (stderrLogStream) {
+      *stderrLogStream << "[system] " << line << std::endl;
+    }
+  }
   if (!ans || ans.get() != 0) {
-    cerr << "Response at initialization of player <" << command << "> ("
-   << ans << ") is non-zero" << endl;
+    if (stderrLogStream) {
+      *stderrLogStream << "[system] Failed... : hand shake" << endl;
+    }
+    if (!child->running()) {
+      std::cerr << "player : \"" << name << "\" is died." << std::endl;
+      std::cerr << "\texit code : " << child->exit_code() << std::endl;
+      if (stderrLogStream) {
+        *stderrLogStream << "[system] your AI : \"" << name << "\" is died." << std::endl;
+        *stderrLogStream << "[system] \texit code : " << child->exit_code() << std::endl;
+      }
+      status = Status::DIED;
+      return;
+    }
+    if (ans) {
+      int v = ans.get();
+      cerr << "Response at initialization of player \"" << name << "\" : ("
+     << v << ") is non-zero" << endl;
+      if (stderrLogStream) {
+        *stderrLogStream << "[system] Response at initialization of player \"" << name << "\" : (" << v << ") is non-zero" << std::endl;
+      }
+    }
     status = Status::INVALID;
+  } else { 
+    if (stderrLogStream) {
+      *stderrLogStream << "[system] Success! : hand shake" << endl;
+    }
   }
 }
 
-static void readAct(std::unique_ptr<boost::process::ipstream> in, std::promise<std::pair<std::unique_ptr<boost::process::ipstream>, boost::optional<std::pair<int, int>>>> p)
+using Message4Act = std::pair<boost::optional<std::pair<int, int>>, std::vector<std::string>>;
+
+static void readAct(std::unique_ptr<boost::process::ipstream> in, std::promise<std::pair<std::unique_ptr<boost::process::ipstream>, Message4Act>> p)
 {
   auto ax = readInt(in);
   auto ay = readInt(in);
 
-  if (ax && ay) {
-    p.set_value(make_pair(std::move(in), make_pair(ax.get(), ay.get())));
+  std::vector<std::string> msg;
+  msg.insert(msg.end(), ax.second.begin(), ax.second.end());
+  msg.insert(msg.end(), ay.second.begin(), ay.second.end());
+  if (ax.first && ay.first) {
+    p.set_value(
+      make_pair(
+        std::move(in),
+        make_pair(
+          boost::optional<std::pair<int, int>>(make_pair(ax.first.get(), ay.first.get())),
+          msg
+        )
+      )
+    );
   } else {
-    p.set_value(make_pair(std::move(in), boost::none));
+    p.set_value(make_pair(std::move(in), make_pair(boost::none, msg)));
   }
 }
 
 IntVec Player::play(int c, Player &op, RaceCourse &course) {
-  sendToAI(toAI, logOutput, "%d\n", c);
-  sendToAI(toAI, logOutput, "%d\n", timeLeft);
-  sendToAI(toAI, logOutput, "%d ", position.x);
-  sendToAI(toAI, logOutput, "%d ", position.y);
-  sendToAI(toAI, logOutput, "%d ", velocity.x);
-  sendToAI(toAI, logOutput, "%d\n", velocity.y);
-  sendToAI(toAI, logOutput, "%d ", op.position.x);
-  sendToAI(toAI, logOutput, "%d ", op.position.y);
-  sendToAI(toAI, logOutput, "%d ", op.velocity.x);
-  sendToAI(toAI, logOutput, "%d\n", op.velocity.y);
+  if (stderrLogStream) {
+    *stderrLogStream << "[system] ================================" << std::endl;
+    *stderrLogStream << "[system] turn: " << c << std::endl;
+  }
+  sendToAI(toAI, stdinLogStream, "%d\n", c);
+  sendToAI(toAI, stdinLogStream, "%d\n", timeLeft);
+  sendToAI(toAI, stdinLogStream, "%d ", position.x);
+  sendToAI(toAI, stdinLogStream, "%d ", position.y);
+  sendToAI(toAI, stdinLogStream, "%d ", velocity.x);
+  sendToAI(toAI, stdinLogStream, "%d\n", velocity.y);
+  sendToAI(toAI, stdinLogStream, "%d ", op.position.x);
+  sendToAI(toAI, stdinLogStream, "%d ", op.position.y);
+  sendToAI(toAI, stdinLogStream, "%d ", op.velocity.x);
+  sendToAI(toAI, stdinLogStream, "%d\n", op.velocity.y);
   for (int y = position.y-course.vision;
        y <= position.y+course.vision;
        y++) {
     for (int x = 0; x != course.width; x++) {
-      sendToAI(toAI, logOutput, "%d ",
+      sendToAI(toAI, stdinLogStream, "%d ",
          (y < 0 || y > course.length ||
     course.obstacle[x][y] ? 1 : 0));
     }
-    sendToAI(toAI, logOutput, "\n", 0);
+    sendToAI(toAI, stdinLogStream, "\n", 0);
   }
-  flushToAI(toAI, logOutput);
-  std::promise<std::pair<std::unique_ptr<boost::process::ipstream>, boost::optional<std::pair<int, int>>>> promise;
-  std::future<std::pair<std::unique_ptr<boost::process::ipstream>, boost::optional<std::pair<int, int>>>> future = promise.get_future();
+  flushToAI(toAI, stdinLogStream);
+  std::promise<std::pair<std::unique_ptr<boost::process::ipstream>, Message4Act>> promise;
+  std::future<std::pair<std::unique_ptr<boost::process::ipstream>, Message4Act>> future = promise.get_future();
+  stderrLogger->mutex.unlock();
+  if (resumeCommand) {
+    std::error_code ec;
+    int result = boost::process::system(resumeCommand.get(), ec);
+    std::cerr << __FILE__ << ":" << __LINE__ << ": [resume] (" << name << ") return code : " << result << ", error value : " << ec.value() << ", error message : " << ec.message() << std::endl;
+  }
   std::chrono::milliseconds remain(timeLeft);
-  std::chrono::system_clock::time_point start = std::chrono::system_clock::now();
   std::thread thread(readAct, std::move(fromAI), std::move(promise));
+  std::chrono::system_clock::time_point start = std::chrono::system_clock::now();
   std::future_status result = future.wait_for(remain);
   std::chrono::system_clock::time_point end = std::chrono::system_clock::now();
-  timeLeft -= std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+  auto timeUsed = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+  timeLeft -= timeUsed;
   thread.join();
+  stderrLogger->mutex.lock();
+  if (stderrLogStream) {
+    *stderrLogStream << "[system] spend time: " << timeUsed << ", remain: " << timeLeft << endl;
+  }
+  if (pauseCommand) {
+    std::error_code ec;
+    int result = boost::process::system(pauseCommand.get(), ec);
+    std::cerr << __FILE__ << ":" << __LINE__ << ": [pause] (" << name << ") return code : " << result << ", error value : " << ec.value() << ", error message : " << ec.message() << std::endl;
+  }
   if (result == std::future_status::timeout) {
     status = Status::TIMEOUT;
     std::cerr << "player : " << name << " has been timeouted" << std::endl;
+    if (stderrLogStream) {
+      *stderrLogStream << "[system] your AI : \"" << name << "\" has been timeouted" << std::endl;
+    }
     return IntVec();
   }
   auto ret = future.get();
   fromAI = std::move(ret.first);
-  if (ret.second) {
-    auto val = ret.second.get();
+  for (const auto& line : ret.second.second) {
+    std::cerr << line << std::endl;
+    if (stderrLogStream) {
+      *stderrLogStream << "[system] " << line << std::endl;
+    }
+  }
+  if (ret.second.first) {
+    auto val = ret.second.first.get();
     if (val.first < -1 || 1 < val.first
       || val.second < -1 || 1 < val.second) {
-      std::cerr << "acceleration value must be from -1 to 1 each axis, but player : " << name << " saied : (" << val.first << ", " << val.second << ")" << std::endl;
+      std::cerr << "acceleration value must be from -1 to 1 each axis, but player : \"" << name << "\" saied : (" << val.first << ", " << val.second << ")" << std::endl;
+      if (stderrLogStream) {
+        *stderrLogStream << "[system] acceleration value must be from -1 to 1 each axis, but your AI : \"" << name << "\" saied : (" << val.first << ", " << val.second << ")" << std::endl;
+      }
       status = Status::INVALID;
       return IntVec();
     }
@@ -159,6 +303,10 @@ IntVec Player::play(int c, Player &op, RaceCourse &course) {
     if (!child->running()) {
       std::cerr << "player : \"" << name << "\" is died." << std::endl;
       std::cerr << "\texit code : " << child->exit_code() << std::endl;
+      if (stderrLogStream) {
+        *stderrLogStream << "[system] your AI : \"" << name << "\" is died." << std::endl;
+        *stderrLogStream << "[system] \texit code : " << child->exit_code() << std::endl;
+      }
       status = Status::DIED;
       return IntVec();
     }

--- a/official/raceState.cpp
+++ b/official/raceState.cpp
@@ -7,12 +7,13 @@ StepRecord::StepRecord(int step, PlayerState bfr, IntVec accel,
 
 
 RaceState::RaceState(RaceCourse &course,
-		     string &player0, string &name0, FILE* logFile0,
-		     string &player1, string &name1, FILE* logFile1):
+		     string &player0, string &name0,
+		     string &player1, string &name1,
+         const std::array<Option, 2>& options):
   course(&course),
   players{
-      Player(player0, course, course.startX[0], name0, logFile0),
-	Player(player1, course, course.startX[1], name1, logFile1)} {
+      Player(player0, course, course.startX[0], name0, options[0]),
+	Player(player1, course, course.startX[1], name1, options[1])} {
   goalTime[0] = goalTime[1] = 2*course.stepLimit;
   goaled[0] = goaled[1] = false;
 }

--- a/official/raceState.hpp
+++ b/official/raceState.hpp
@@ -1,5 +1,9 @@
 #include <list>
 #include <cstdio>
+#include <memory>
+#include <fstream>
+
+#include <boost/optional.hpp>
 
 #include "course.hpp"
 #include "player.hpp"
@@ -34,6 +38,8 @@ struct StepRecord {
 
 ostream &operator<<(ostream &out, const StepRecord &r);
 
+struct Option;
+
 struct RaceState {
   RaceCourse *course;
   Player players[2];
@@ -41,8 +47,8 @@ struct RaceState {
   double goalTime[2];
   list<StepRecord> records[2];
   RaceState(RaceCourse &course,
-	    string& player0, string &name0, FILE* logFile0,
-	    string &player1, string &name1, FILE* logFile1);
+	    string& player0, string &name0,
+	    string &player1, string &name1, const std::array<Option, 2>& options);
   bool playOneStep(int c);
 };
 


### PR DESCRIPTION
fix #21 #22

追加：
boost::program_optionsを持ちい、
- stderr出力のログ
- Docker用に停止・再開コマンドの受け付け
をできるようにした

変更：
optionの書式を揃えるために
- AIへの標準入力のオプション形式の変更
- FILE* の廃止
を行った