### PR TITLE
[official] Fix obstacle

### DIFF
--- a/official/course.cpp
+++ b/official/course.cpp
@@ -173,18 +173,6 @@ RaceCourse::RaceCourse(istream &in) {
   startX[0] = courseTree.get<int>("x0");
   startX[1] = courseTree.get<int>("x1");
   obstacle = std::move(Obstacle(courseTree.get_child("obstacles")));
-  cerr << "     ";
-  for (int x = -3; x <= width + 3; ++x) {
-    cerr << setw(3) << x;
-  }
-  cerr << endl;
-  for (int y = length + 8; -8 <= y; --y) {
-    cerr << setw(3) << y << ": ";
-    for (int x = -3; x <= width + 3; ++x) {
-      cerr << setw(3) << (obstacle[y][x] ? "*" : (y == length ? "=" : " "));
-    }
-    cerr << endl;
-  }
 }
 
 void IntVec::writeJson(ostream &out) {

--- a/official/course.cpp
+++ b/official/course.cpp
@@ -49,32 +49,32 @@ bool RaceCourse::collides(const LineSegment &m) const {
   int
     x1 = m.p1.x, y1 = m.p1.y,
     x2 = m.p2.x, y2 = m.p2.y;
-  if (obstacle[x2][y2]) return true;
+  if (obstacle[y2][x2]) return true;
   int xstep = x2 > x1 ? 1 : -1;
   if (y1 == y2) {
     for (int x = x1; x != x2; x += xstep) {
-      if (obstacle[x][y1]) return true;
+      if (obstacle[y1][x]) return true;
     }
     return false;
   }
   int ystep = y2 > y1 ? 1 : -1;
   if (x1 == x2) {
     for (int y = y1; y != y2; y += ystep) {
-      if (obstacle[x1][y]) return true;
+      if (obstacle[y][x1]) return true;
     }
     return false;
   }
-  for (int x = x1; x != x2; x += xstep) {
-    int nx = x + xstep;
-    for (int y = y1; y != y2; y += ystep) {
-      int ny = y + ystep;
-      if ((obstacle[x][y] && obstacle[nx][ny] &&
+  for (int y = y1; y != y2; y += ystep) {
+    int ny = y + ystep;
+    for (int x = x1; x != x2; x += xstep) {
+      int nx = x + xstep;
+      if ((obstacle[y][x] && obstacle[ny][nx] &&
 	   LineSegment(Point(x, y), Point(nx, ny)).intersects(m)) ||
-	  (obstacle[x][ny] && obstacle[nx][ny] &&
+	  (obstacle[ny][x] && obstacle[ny][nx] &&
 	   LineSegment(Point(x, ny), Point(nx, ny)).intersects(m)) ||
-	  (obstacle[nx][y] && obstacle[nx][ny] &&
+	  (obstacle[y][nx] && obstacle[ny][nx] &&
 	   LineSegment(Point(nx, y), Point(nx, ny)).intersects(m)) ||
-	  (obstacle[x][ny] && obstacle[nx][y] &&
+	  (obstacle[ny][x] && obstacle[y][nx] &&
 	   LineSegment(Point(x, ny), Point(nx, y)).intersects(m))) {
 	return true;
       }
@@ -174,21 +174,7 @@ RaceCourse::RaceCourse(istream &in) {
   stepLimit = courseTree.get<int>("stepLimit");
   startX[0] = courseTree.get<int>("x0");
   startX[1] = courseTree.get<int>("x1");
-  int y = 0;
-  obstacle = vector<vector<bool>>(width);
-  for (int x = 0; x != width; x++) obstacle[x] = vector<bool>(length);
-  for (auto &row: courseTree.get_child("obstacles")) {
-    int x = 0;
-    for (auto &obst: row.second)
-      obstacle[x++][y] = (obst.second.get_value<int>() != 0);
-    y++;
-  }
-  _obstacle = std::move(Obstacle(courseTree.get_child("obstacles")));
-  for (int y = 0; y < length; ++y) {
-    for (int x = 0; x < width; ++x) {
-      assert(_obstacle[y][x] == obstacle[x][y]);
-    }
-  }
+  obstacle = std::move(Obstacle(courseTree.get_child("obstacles")));
 }
 
 void IntVec::writeJson(ostream &out) {
@@ -201,15 +187,21 @@ void RaceCourse::writeJson(ostream &out) {
       << "   \"width\": " << width  << ", \"length\": " << length << ',' << endl
       << "   \"x0\": " << startX[0] << ", \"x1\": " << startX[1] << ',' << endl;
   out << "  \"obstacles\": [";
-  for (int y = 0; y != length; y++) {
-    out << "     [";
-    for (int x = 0; x != width; x++) {
-      out << (obstacle[x][y] ? '1' : '0')
-	  << (x == width-1 ? "" : ", ");
+  int i = 0;
+  for (const auto& col : obstacle) {
+    if (i++) {
+      out << ",";
+      out << endl;
     }
-    out << "]"
-	<< (y == length-1 ? "" : ",")
-	<< endl;
+    out << "     [";
+    int j = 0;
+    for (const auto& obs : col) {
+      if (j++) {
+        out << ", ";
+      }
+      out << (obs ? 1 : 0);
+    }
+    out << "]";
   }
   out << "]" << endl
       << "}" << endl;

--- a/official/course.cpp
+++ b/official/course.cpp
@@ -103,13 +103,12 @@ Obstacle::Obstacle(const boost::property_tree::ptree& tree) : UNDER(true), OVER(
   rows = 0;
   raw = {};
   for (const auto& v : tree) {
-    Obstacle::ObstacleCol col(v.second);
-    raw.push_back(std::make_shared<Obstacle::ObstacleCol>(col));
+    raw.push_back(std::make_shared<Obstacle::ObstacleCol>(v.second));
     ++rows;
   }
 }
 const Obstacle::ObstacleCol& Obstacle::operator[](int pos) {
-  if (0 < pos) {
+  if (pos < 0) {
     return UNDER;
   }
   if (rows <= pos) {
@@ -142,6 +141,12 @@ RaceCourse::RaceCourse(istream &in) {
     for (auto &obst: row.second)
       obstacle[x++][y] = (obst.second.get_value<int>() != 0);
     y++;
+  }
+  _obstacle = std::unique_ptr<Obstacle>(new Obstacle(courseTree.get_child("obstacles")));
+  for (int y = 0; y < length; ++y) {
+    for (int x = 0; x < width; ++x) {
+      assert((*_obstacle)[y][x] == obstacle[x][y]);
+    }
   }
 }
 

--- a/official/course.cpp
+++ b/official/course.cpp
@@ -83,8 +83,8 @@ bool RaceCourse::collides(const LineSegment &m) const {
   return false;
 }
 
-Obstacle::Obstacle_Impl::ObstacleCol::ObstacleCol(bool outer) : DEFAULT(outer), cols(0), col({}) {}
-Obstacle::Obstacle_Impl::ObstacleCol::ObstacleCol(const boost::property_tree::ptree& tree) : DEFAULT(true) {
+ObstacleCol::ObstacleCol_Impl::ObstacleCol_Impl(bool outer) : DEFAULT(outer), cols(0), col({}) {}
+ObstacleCol::ObstacleCol_Impl::ObstacleCol_Impl(const boost::property_tree::ptree& tree) : DEFAULT(true) {
   cols = 0;
   col = {};
   for (const auto& v : tree) {
@@ -92,36 +92,70 @@ Obstacle::Obstacle_Impl::ObstacleCol::ObstacleCol(const boost::property_tree::pt
     ++cols;
   }
 }
-bool Obstacle::Obstacle_Impl::ObstacleCol::operator[](int pos) const {
+bool ObstacleCol::ObstacleCol_Impl::operator[](int pos) const {
   if (0 <= pos && pos < cols) {
     return col[pos];
   }
   return DEFAULT;
+}
+ObstacleCol::ObstacleCol_Impl::const_iterator ObstacleCol::ObstacleCol_Impl::begin() const {
+  return col.begin();
+}
+ObstacleCol::ObstacleCol_Impl::const_iterator ObstacleCol::ObstacleCol_Impl::end() const {
+  return col.end();
+}
+
+ObstacleCol::ObstacleCol(bool outer) {
+  col_ptr = std::make_shared<ObstacleCol_Impl>(outer);
+}
+ObstacleCol::ObstacleCol(const boost::property_tree::ptree& tree) {
+  col_ptr = std::make_shared<ObstacleCol_Impl>(tree);
+}
+bool ObstacleCol::operator[](int pos) const {
+  return (*col_ptr)[pos];
+}
+decltype(ObstacleCol::col_ptr->begin()) ObstacleCol::begin() const {
+  return col_ptr->begin();
+}
+decltype(ObstacleCol::col_ptr->end()) ObstacleCol::end() const {
+  return col_ptr->end();
 }
 
 Obstacle::Obstacle_Impl::Obstacle_Impl(const boost::property_tree::ptree& tree) : UNDER(true), OVER(false) {
   rows = 0;
   raw = {};
   for (const auto& v : tree) {
-    raw.push_back(std::make_shared<Obstacle::Obstacle_Impl::ObstacleCol>(v.second));
+    raw.push_back(ObstacleCol(v.second));
     ++rows;
   }
 }
-const Obstacle::Obstacle_Impl::ObstacleCol& Obstacle::Obstacle_Impl::operator[](int pos) const {
+const ObstacleCol& Obstacle::Obstacle_Impl::operator[](int pos) const {
   if (pos < 0) {
     return UNDER;
   }
   if (rows <= pos) {
     return OVER;
   }
-  return *raw[pos];
+  return raw[pos];
+}
+Obstacle::Obstacle_Impl::const_iterator Obstacle::Obstacle_Impl::begin() const {
+  return raw.begin();
+}
+Obstacle::Obstacle_Impl::const_iterator Obstacle::Obstacle_Impl::end() const {
+  return raw.end();
 }
 
 Obstacle::Obstacle(const boost::property_tree::ptree& tree) {
-  obstacle_ptr = std::make_shared<Obstacle::Obstacle_Impl>(tree);
+  obstacle_ptr = std::make_shared<Obstacle_Impl>(tree);
 }
-const Obstacle::Obstacle_Impl::ObstacleCol& Obstacle::operator[](int pos) const {
+const ObstacleCol& Obstacle::operator[](int pos) const {
   return (*obstacle_ptr)[pos];
+}
+decltype(Obstacle::obstacle_ptr->begin()) Obstacle::begin() const {
+  return obstacle_ptr->begin();
+}
+decltype(Obstacle::obstacle_ptr->end()) Obstacle::end() const {
+  return obstacle_ptr->end();
 }
 
 const string CourseDataFileType = "race course";

--- a/official/course.cpp
+++ b/official/course.cpp
@@ -83,6 +83,41 @@ bool RaceCourse::collides(const LineSegment &m) const {
   return false;
 }
 
+Obstacle::ObstacleCol::ObstacleCol(bool outer) : DEFAULT(outer), cols(0), col({}) {}
+Obstacle::ObstacleCol::ObstacleCol(const boost::property_tree::ptree& tree) : DEFAULT(true) {
+  cols = 0;
+  col = {};
+  for (const auto& v : tree) {
+    col.push_back(v.second.get_value<int>() == 1);
+    ++cols;
+  }
+}
+bool Obstacle::ObstacleCol::operator[](int pos) const {
+  if (0 <= pos && pos < cols) {
+    return col[pos];
+  }
+  return DEFAULT;
+}
+
+Obstacle::Obstacle(const boost::property_tree::ptree& tree) : UNDER(true), OVER(false) {
+  rows = 0;
+  raw = {};
+  for (const auto& v : tree) {
+    Obstacle::ObstacleCol col(v.second);
+    raw.push_back(std::make_shared<Obstacle::ObstacleCol>(col));
+    ++rows;
+  }
+}
+const Obstacle::ObstacleCol& Obstacle::operator[](int pos) {
+  if (0 < pos) {
+    return UNDER;
+  }
+  if (rows <= pos) {
+    return OVER;
+  }
+  return *raw[pos];
+}
+
 const string CourseDataFileType = "race course";
 
 RaceCourse::RaceCourse(istream &in) {

--- a/official/course.hpp
+++ b/official/course.hpp
@@ -61,6 +61,7 @@ struct RaceCourse {
   int vision;
   int thinkTime, stepLimit;
   int startX[2];
+  std::unique_ptr<Obstacle> _obstacle;
   vector <vector <bool>> obstacle;
   RaceCourse(istream &in);
   bool collides(const LineSegment &m) const;

--- a/official/course.hpp
+++ b/official/course.hpp
@@ -87,8 +87,7 @@ struct RaceCourse {
   int vision;
   int thinkTime, stepLimit;
   int startX[2];
-  Obstacle _obstacle;
-  vector <vector <bool>> obstacle;
+  Obstacle obstacle;
   RaceCourse(istream &in);
   bool collides(const LineSegment &m) const;
   void writeJson(ostream &out);

--- a/official/course.hpp
+++ b/official/course.hpp
@@ -26,25 +26,33 @@ struct IntVec {
 typedef IntVec Point;
 
 class Obstacle {
-public:
-  class ObstacleCol {
-  private:
-    const bool DEFAULT;
-    int cols;
-    std::vector<bool> col;
-  public:
-    ObstacleCol(bool outer);
-    ObstacleCol(const boost::property_tree::ptree& tree);
-    bool operator[](int pos) const;
-  };
 private:
-  const ObstacleCol UNDER;
-  const ObstacleCol OVER;
-  int rows;
-  std::vector<std::shared_ptr<ObstacleCol>> raw;
+  class Obstacle_Impl {
+  public:
+    class ObstacleCol {
+    private:
+      const bool DEFAULT;
+      int cols;
+      std::vector<bool> col;
+    public:
+      ObstacleCol(bool outer);
+      ObstacleCol(const boost::property_tree::ptree& tree);
+      bool operator[](int pos) const;
+    };
+  private:
+    const ObstacleCol UNDER;
+    const ObstacleCol OVER;
+    int rows;
+    std::vector<std::shared_ptr<ObstacleCol>> raw;
+  public:
+    Obstacle_Impl(const boost::property_tree::ptree& tree);
+    const Obstacle_Impl::ObstacleCol& operator[](int pos) const;
+  };
+  std::shared_ptr<Obstacle_Impl> obstacle_ptr;
 public:
   Obstacle(const boost::property_tree::ptree& tree);
-  const Obstacle::ObstacleCol& operator[](int pos);
+  const Obstacle::Obstacle_Impl::ObstacleCol& operator[](int pos) const;
+  Obstacle() = default;
 };
 
 struct LineSegment {
@@ -61,7 +69,7 @@ struct RaceCourse {
   int vision;
   int thinkTime, stepLimit;
   int startX[2];
-  std::unique_ptr<Obstacle> _obstacle;
+  Obstacle _obstacle;
   vector <vector <bool>> obstacle;
   RaceCourse(istream &in);
   bool collides(const LineSegment &m) const;

--- a/official/course.hpp
+++ b/official/course.hpp
@@ -27,31 +27,19 @@ typedef IntVec Point;
 
 class ObstacleCol {
 private:
-  class ObstacleCol_Impl {
-  private:
-    using const_iterator = std::vector<bool>::const_iterator;
-    const bool DEFAULT;
-    int cols;
-    std::vector<bool> col;
-  public:
-    ObstacleCol_Impl(bool outer);
-    ObstacleCol_Impl(const boost::property_tree::ptree& tree);
-    bool operator[](int pos) const;
-    const_iterator begin() const;
-    const_iterator end() const;
-  };
-  std::shared_ptr<ObstacleCol_Impl> col_ptr;
+  using const_iterator = std::vector<bool>::const_iterator;
+  int cols;
+  std::vector<bool> col;
 public:
-  ObstacleCol(bool outer);
+  ObstacleCol(bool obs, size_t size);
   ObstacleCol(const boost::property_tree::ptree& tree);
   bool operator[](int pos) const;
-  decltype(col_ptr->begin()) begin() const;
-  decltype(col_ptr->end()) end() const;
+  const_iterator begin() const;
+  const_iterator end() const;
 };
 class Obstacle {
 private:
   class Obstacle_Impl {
-  public:
   private:
     using const_iterator = std::vector<ObstacleCol>::const_iterator;
     const ObstacleCol UNDER;

--- a/official/course.hpp
+++ b/official/course.hpp
@@ -25,6 +25,28 @@ struct IntVec {
 
 typedef IntVec Point;
 
+class Obstacle {
+public:
+  class ObstacleCol {
+  private:
+    const bool DEFAULT;
+    int cols;
+    std::vector<bool> col;
+  public:
+    ObstacleCol(bool outer);
+    ObstacleCol(const boost::property_tree::ptree& tree);
+    bool operator[](int pos) const;
+  };
+private:
+  const ObstacleCol UNDER;
+  const ObstacleCol OVER;
+  int rows;
+  std::vector<std::shared_ptr<ObstacleCol>> raw;
+public:
+  Obstacle(const boost::property_tree::ptree& tree);
+  const Obstacle::ObstacleCol& operator[](int pos);
+};
+
 struct LineSegment {
   Point p1, p2;
   LineSegment() {};

--- a/official/course.hpp
+++ b/official/course.hpp
@@ -25,34 +25,52 @@ struct IntVec {
 
 typedef IntVec Point;
 
+class ObstacleCol {
+private:
+  class ObstacleCol_Impl {
+  private:
+    using const_iterator = std::vector<bool>::const_iterator;
+    const bool DEFAULT;
+    int cols;
+    std::vector<bool> col;
+  public:
+    ObstacleCol_Impl(bool outer);
+    ObstacleCol_Impl(const boost::property_tree::ptree& tree);
+    bool operator[](int pos) const;
+    const_iterator begin() const;
+    const_iterator end() const;
+  };
+  std::shared_ptr<ObstacleCol_Impl> col_ptr;
+public:
+  ObstacleCol(bool outer);
+  ObstacleCol(const boost::property_tree::ptree& tree);
+  bool operator[](int pos) const;
+  decltype(col_ptr->begin()) begin() const;
+  decltype(col_ptr->end()) end() const;
+};
 class Obstacle {
 private:
   class Obstacle_Impl {
   public:
-    class ObstacleCol {
-    private:
-      const bool DEFAULT;
-      int cols;
-      std::vector<bool> col;
-    public:
-      ObstacleCol(bool outer);
-      ObstacleCol(const boost::property_tree::ptree& tree);
-      bool operator[](int pos) const;
-    };
   private:
+    using const_iterator = std::vector<ObstacleCol>::const_iterator;
     const ObstacleCol UNDER;
     const ObstacleCol OVER;
     int rows;
-    std::vector<std::shared_ptr<ObstacleCol>> raw;
+    std::vector<ObstacleCol> raw;
   public:
     Obstacle_Impl(const boost::property_tree::ptree& tree);
-    const Obstacle_Impl::ObstacleCol& operator[](int pos) const;
+    const ObstacleCol& operator[](int pos) const;
+    const_iterator begin() const;
+    const_iterator end() const;
   };
   std::shared_ptr<Obstacle_Impl> obstacle_ptr;
 public:
   Obstacle(const boost::property_tree::ptree& tree);
-  const Obstacle::Obstacle_Impl::ObstacleCol& operator[](int pos) const;
+  const ObstacleCol& operator[](int pos) const;
   Obstacle() = default;
+  decltype(obstacle_ptr->begin()) begin() const;
+  decltype(obstacle_ptr->end()) end() const;
 };
 
 struct LineSegment {

--- a/official/player.cpp
+++ b/official/player.cpp
@@ -236,13 +236,12 @@ IntVec Player::play(int c, Player &op, RaceCourse &course) {
   sendToAI(toAI, stdinLogStream, "%d ", op.position.y);
   sendToAI(toAI, stdinLogStream, "%d ", op.velocity.x);
   sendToAI(toAI, stdinLogStream, "%d\n", op.velocity.y);
-  for (int y = position.y-course.vision;
-       y <= position.y+course.vision;
-       y++) {
-    for (int x = 0; x != course.width; x++) {
-      sendToAI(toAI, stdinLogStream, "%d ",
-         (y < 0 || y > course.length ||
-    course.obstacle[x][y] ? 1 : 0));
+  for (int dy = -course.vision; dy <= course.vision; ++dy) {
+    for (int x = 0; x < course.width; ++x) {
+      if (x) {
+        sendToAI(toAI, stdinLogStream, " ", 0);
+      }
+      sendToAI(toAI, stdinLogStream, "%d", course.obstacle[position.y + dy][x] ? 1 : 0);
     }
     sendToAI(toAI, stdinLogStream, "\n", 0);
   }

--- a/official/player.cpp
+++ b/official/player.cpp
@@ -54,9 +54,10 @@ static void handShake(std::unique_ptr<boost::process::ipstream> in, std::promise
 
 void sendToAI(std::unique_ptr<boost::process::opstream>&  toAI, std::shared_ptr<std::ofstream> stdinLogStream, const char *fmt, int value) {
   int n = std::snprintf(nullptr, 0, fmt, value);
-  auto cstr = new std::unique_ptr<char[]>(new char[n + 2]);
-  std::snprintf(cstr->get(), n + 1, fmt, value);
-  std::string str(cstr->get());
+  std::unique_ptr<char[]> cstr(new char[n + 2]);
+  std::memset(cstr.get(), 0, n + 2);
+  std::snprintf(cstr.get(), n + 1, fmt, value);
+  std::string str(cstr.get());
   *toAI << str;
   if (stdinLogStream.get() != nullptr) {
     *stdinLogStream << str;

--- a/official/raceState.cpp
+++ b/official/raceState.cpp
@@ -45,8 +45,7 @@ bool RaceState::playOneStep(int c) {
       nextVelocity[p] = players[p].velocity + accel[p];
       nextPosition[p] = players[p].position + nextVelocity[p];
       move[p] = LineSegment(players[p].position, nextPosition[p]);
-      if (nextPosition[p].x < 0 || course->width <= nextPosition[p].x ||
-	  nextPosition[p].y < 0 || course->collides(move[p])) {
+      if (course->collides(move[p])) {
 	res[p] = STOPPED;
       }
     }


### PR DESCRIPTION
#25 のゲームマネージャ：officialの修整です。

Segmentation fault を起こすのが怖かったので少し整理してみましたが、
返って煩雑になってしまったかもしれません…。
Obstacleのclassを新たに定義しました（再度定義し直しました）。

`y < 0` のときはtrue、 `y >= course.length` のときはfalseになるようにしています。

greedy同士の対戦でAIへの入力、出力のjsonを
前バージョンと差分を取り問題ないことを確認しました。
ただ、
- jsonのフォーマットが少し変わり、
- AIへのobstacleの入力について末尾の空白を除去し、
- 前バージョンでは `y >= course.length` でtrueを返すようになっていたため修整した

という差異があります。