### PR TITLE
[official] fix collision and input

### DIFF
--- a/official/player.cpp
+++ b/official/player.cpp
@@ -237,10 +237,18 @@ IntVec Player::play(int c, Player &op, RaceCourse &course) {
   sendToAI(toAI, option.stdinLogStream, "%d ", position.y);
   sendToAI(toAI, option.stdinLogStream, "%d ", velocity.x);
   sendToAI(toAI, option.stdinLogStream, "%d\n", velocity.y);
-  sendToAI(toAI, option.stdinLogStream, "%d ", op.position.x);
-  sendToAI(toAI, option.stdinLogStream, "%d ", op.position.y);
-  sendToAI(toAI, option.stdinLogStream, "%d ", op.velocity.x);
-  sendToAI(toAI, option.stdinLogStream, "%d\n", op.velocity.y);
+  if (std::abs(op.position.y - position.y) <= course.vision
+      && op.status == Status::VALID) {
+    sendToAI(toAI, option.stdinLogStream, "%d ", op.position.x);
+    sendToAI(toAI, option.stdinLogStream, "%d ", op.position.y);
+    sendToAI(toAI, option.stdinLogStream, "%d ", op.velocity.x);
+    sendToAI(toAI, option.stdinLogStream, "%d\n", op.velocity.y);
+  } else {
+    sendToAI(toAI, option.stdinLogStream, "%d ", 0);
+    sendToAI(toAI, option.stdinLogStream, "%d ", -1);
+    sendToAI(toAI, option.stdinLogStream, "%d ", 0);
+    sendToAI(toAI, option.stdinLogStream, "%d\n", 0);
+  }
   for (int dy = -course.vision; dy <= course.vision; ++dy) {
     for (int x = 0; x < course.width; ++x) {
       if (x) {

--- a/official/player.hpp
+++ b/official/player.hpp
@@ -16,6 +16,7 @@ struct Option {
 
 enum struct Status {
   VALID = 0,
+  GOALED = 1,
   TIMEOUT = -1,
   INVALID = -2,
   DIED = -3

--- a/official/raceState.cpp
+++ b/official/raceState.cpp
@@ -50,17 +50,18 @@ bool RaceState::playOneStep(int c) {
       }
     }
   }
-  // Going through the opponent's position is not allowed even with precedence
-  for (int i = 0; i < 2; ++i) {
-    if (res[i] == FUNNY) {
-      continue;
-    }
-    if (move[i].goesThru(players[1 - i].position)) {
-      res[i] = STOPPED;
-    }
-  }
   if (!goaled[0] && !goaled[1]) {
-    // Check collision
+    // Check collision if both sides have not reached the goal yet
+    // Going through the opponent's position is not allowed even with precedence
+    for (int i = 0; i < 2; ++i) {
+      if (res[i] == FUNNY) {
+        continue;
+      }
+      if (move[i].goesThru(players[1 - i].position)) {
+        res[i] = STOPPED;
+      }
+    }
+    // Check intersection
     bool moveCollision = move[0].intersects(move[1]) && res[0] == NORMAL && res[1] == NORMAL;
     if (moveCollision) {
       bool prec0 =
@@ -91,6 +92,7 @@ bool RaceState::playOneStep(int c) {
       if (res[p] == NORMAL) {
 	if (nextPosition[p].y >= course->length) {
 	  goaled[p] = true;
+	  players[p].status = Status::GOALED;
 	  goalTime[p] =
 	    c-1+
 	    (double)(course->length- players[p].position.y)/nextVelocity[p].y;


### PR DESCRIPTION
fix #47 

#15 の修整でゴールした相手に対しても
プレイヤーの位置を通過するかチェックしていましたが
これを修整しました。

また、

- 視界外の相手プレイヤー
- ゴールした相手プレイヤー
- タイムアウトなどで棄権になった相手プレイヤー

について、プレイヤーへの入力を

https://github.com/SamurAI-Coding/Software2017-18/blob/07c7879b33bee84988ccb9e0c0fb810658940118/documents/rule-en.tex#L218-L220
https://github.com/SamurAI-Coding/Software2017-18/blob/07c7879b33bee84988ccb9e0c0fb810658940118/documents/rule-jp.tex#L191

となるように修整しました。

- [test.smrjky.txt](https://github.com/SamurAI-Coding/Software2017-18/files/1538861/test.smrjky.txt) : 動作確認に用いたコースファイル
- [test.prev.log.txt](https://github.com/SamurAI-Coding/Software2017-18/files/1538863/test.prev.log.txt) : 07c7879 時点のofficialが出力するゲームログ
- [test.after.log.txt](https://github.com/SamurAI-Coding/Software2017-18/files/1538864/test.after.log.txt) : 今回の修整で出力するゲームログ
- [test.stdin0.after.txt](https://github.com/SamurAI-Coding/Software2017-18/files/1538865/test.stdin0.after.txt) : 今回の修整でplayer0に与えられる入力
