### PR TITLE
Fix wording by using 'stdout' instead of 'stdin'.

### DIFF
--- a/official/main.cpp
+++ b/official/main.cpp
@@ -13,10 +13,10 @@ int main(int argc, char *argv[]) {
 #endif
   boost::program_options::options_description desc("<option>");
   desc.add_options()
-    ("stdinLogFile0", boost::program_options::value<std::string>()->value_name("<filename>"), "logfile name for player0 standard input")
-    ("stdinLogFile1", boost::program_options::value<std::string>()->value_name("<filename>"), "logfile name for player1 standard input")
-    ("stderrLogFile0", boost::program_options::value<std::string>()->value_name("<filename>"), "logfile name for player0 standard error output")
-    ("stderrLogFile1", boost::program_options::value<std::string>()->value_name("<filename>"), "logfile name for player1 standard error output")
+    ("stdoutLogFile0", boost::program_options::value<std::string>()->value_name("<filename>"), "logfile name for player0's standard output")
+    ("stdoutLogFile1", boost::program_options::value<std::string>()->value_name("<filename>"), "logfile name for player1's standard output")
+    ("stderrLogFile0", boost::program_options::value<std::string>()->value_name("<filename>"), "logfile name for player0's standard error")
+    ("stderrLogFile1", boost::program_options::value<std::string>()->value_name("<filename>"), "logfile name for player1's standard error")
     ("pauseP0", boost::program_options::value<std::string>()->value_name("<command>"), "pause command for player0")
     ("resumeP0", boost::program_options::value<std::string>()->value_name("<command>"), "resume command for player0")
     ("pauseP1", boost::program_options::value<std::string>()->value_name("<command>"), "pause command for player1")
@@ -68,7 +68,7 @@ int main(int argc, char *argv[]) {
     }
   };
   for (int i = 0; i < 2; ++i) {
-    options[i].stdinLogStream = take_ofstream(vm, "stdinLogFile" + std::to_string(i));
+    options[i].stdoutLogStream = take_ofstream(vm, "stdoutLogFile" + std::to_string(i));
     options[i].stderrLogStream = take_ofstream(vm, "stderrLogFile" + std::to_string(i));
     options[i].pauseCommand = take_command(vm, "pauseP" + std::to_string(i));
     options[i].resumeCommand = take_command(vm, "resumeP" + std::to_string(i));

--- a/official/player.cpp
+++ b/official/player.cpp
@@ -54,21 +54,21 @@ static void handShake(std::unique_ptr<boost::process::ipstream> in, std::promise
 }
 
 template <class... Args>
-void sendToAI(std::unique_ptr<boost::process::opstream>&  toAI, std::shared_ptr<std::ofstream> stdinLogStream, const char *fmt, Args... args) {
+void sendToAI(std::unique_ptr<boost::process::opstream>&  toAI, std::shared_ptr<std::ofstream> stdoutLogStream, const char *fmt, Args... args) {
   int n = std::snprintf(nullptr, 0, fmt, args...);
   std::unique_ptr<char[]> cstr(new char[n + 2]);
   std::memset(cstr.get(), 0, n + 2);
   std::snprintf(cstr.get(), n + 1, fmt, args...);
   std::string str(cstr.get());
   *toAI << str;
-  if (stdinLogStream.get() != nullptr) {
-    *stdinLogStream << str;
+  if (stdoutLogStream.get() != nullptr) {
+    *stdoutLogStream << str;
   }
 }
 
-void flushToAI(std::unique_ptr<boost::process::opstream>& toAI, std::shared_ptr<std::ofstream> stdinLogStream) {
+void flushToAI(std::unique_ptr<boost::process::opstream>& toAI, std::shared_ptr<std::ofstream> stdoutLogStream) {
   toAI->flush();
-  if (stdinLogStream.get() != nullptr) stdinLogStream->flush();
+  if (stdoutLogStream.get() != nullptr) stdoutLogStream->flush();
 }
 
 static void logging(std::promise<void> promise, std::unique_ptr<std::istream> input, std::shared_ptr<std::ostream> output, std::shared_ptr<std::mutex> mutex, int MAX_SIZE) {
@@ -129,12 +129,12 @@ Player::Player(string command, const RaceCourse &course, int xpos,
     *option.stderrLogStream << "[system] Try : hand shake" << endl;
   }
   stderrLogger = std::unique_ptr<Logger>(new Logger(std::move(stderrFromAI), option.stderrLogStream, 1 << 15));
-  sendToAI(toAI, option.stdinLogStream, "%d\n", course.thinkTime);
-  sendToAI(toAI, option.stdinLogStream, "%d\n", course.stepLimit);
-  sendToAI(toAI, option.stdinLogStream, "%d ", course.width);
-  sendToAI(toAI, option.stdinLogStream, "%d\n", course.length);
-  sendToAI(toAI, option.stdinLogStream, "%d\n", course.vision);
-  flushToAI(toAI, option.stdinLogStream);
+  sendToAI(toAI, option.stdoutLogStream, "%d\n", course.thinkTime);
+  sendToAI(toAI, option.stdoutLogStream, "%d\n", course.stepLimit);
+  sendToAI(toAI, option.stdoutLogStream, "%d ", course.width);
+  sendToAI(toAI, option.stdoutLogStream, "%d\n", course.length);
+  sendToAI(toAI, option.stdoutLogStream, "%d\n", course.vision);
+  flushToAI(toAI, option.stdoutLogStream);
   std::promise<std::pair<std::unique_ptr<boost::process::ipstream>, Message>> promise;
   std::future<std::pair<std::unique_ptr<boost::process::ipstream>, Message>> future = promise.get_future();
   std::chrono::milliseconds remain(timeLeft);
@@ -231,34 +231,34 @@ IntVec Player::play(int c, Player &op, RaceCourse &course) {
     *option.stderrLogStream << "[system] ================================" << std::endl;
     *option.stderrLogStream << "[system] turn: " << c << std::endl;
   }
-  sendToAI(toAI, option.stdinLogStream, "%d\n", c);
-  sendToAI(toAI, option.stdinLogStream, "%" PRId64 "\n", timeLeft);
-  sendToAI(toAI, option.stdinLogStream, "%d ", position.x);
-  sendToAI(toAI, option.stdinLogStream, "%d ", position.y);
-  sendToAI(toAI, option.stdinLogStream, "%d ", velocity.x);
-  sendToAI(toAI, option.stdinLogStream, "%d\n", velocity.y);
+  sendToAI(toAI, option.stdoutLogStream, "%d\n", c);
+  sendToAI(toAI, option.stdoutLogStream, "%" PRId64 "\n", timeLeft);
+  sendToAI(toAI, option.stdoutLogStream, "%d ", position.x);
+  sendToAI(toAI, option.stdoutLogStream, "%d ", position.y);
+  sendToAI(toAI, option.stdoutLogStream, "%d ", velocity.x);
+  sendToAI(toAI, option.stdoutLogStream, "%d\n", velocity.y);
   if (std::abs(op.position.y - position.y) <= course.vision
       && op.status == Status::VALID) {
-    sendToAI(toAI, option.stdinLogStream, "%d ", op.position.x);
-    sendToAI(toAI, option.stdinLogStream, "%d ", op.position.y);
-    sendToAI(toAI, option.stdinLogStream, "%d ", op.velocity.x);
-    sendToAI(toAI, option.stdinLogStream, "%d\n", op.velocity.y);
+    sendToAI(toAI, option.stdoutLogStream, "%d ", op.position.x);
+    sendToAI(toAI, option.stdoutLogStream, "%d ", op.position.y);
+    sendToAI(toAI, option.stdoutLogStream, "%d ", op.velocity.x);
+    sendToAI(toAI, option.stdoutLogStream, "%d\n", op.velocity.y);
   } else {
-    sendToAI(toAI, option.stdinLogStream, "%d ", 0);
-    sendToAI(toAI, option.stdinLogStream, "%d ", -1);
-    sendToAI(toAI, option.stdinLogStream, "%d ", 0);
-    sendToAI(toAI, option.stdinLogStream, "%d\n", 0);
+    sendToAI(toAI, option.stdoutLogStream, "%d ", 0);
+    sendToAI(toAI, option.stdoutLogStream, "%d ", -1);
+    sendToAI(toAI, option.stdoutLogStream, "%d ", 0);
+    sendToAI(toAI, option.stdoutLogStream, "%d\n", 0);
   }
   for (int dy = -course.vision; dy <= course.vision; ++dy) {
     for (int x = 0; x < course.width; ++x) {
       if (x) {
-        sendToAI(toAI, option.stdinLogStream, " ", 0);
+        sendToAI(toAI, option.stdoutLogStream, " ", 0);
       }
-      sendToAI(toAI, option.stdinLogStream, "%d", course.obstacle[position.y + dy][x] ? 1 : 0);
+      sendToAI(toAI, option.stdoutLogStream, "%d", course.obstacle[position.y + dy][x] ? 1 : 0);
     }
-    sendToAI(toAI, option.stdinLogStream, "\n", 0);
+    sendToAI(toAI, option.stdoutLogStream, "\n", 0);
   }
-  flushToAI(toAI, option.stdinLogStream);
+  flushToAI(toAI, option.stdoutLogStream);
   std::promise<std::pair<std::unique_ptr<boost::process::ipstream>, Message4Act>> promise;
   std::future<std::pair<std::unique_ptr<boost::process::ipstream>, Message4Act>> future = promise.get_future();
   stderrLogger->mutex->unlock();

--- a/official/player.hpp
+++ b/official/player.hpp
@@ -8,7 +8,7 @@
 
 struct RaceCourse;
 struct Option {
-  std::shared_ptr<std::ofstream> stdinLogStream;
+  std::shared_ptr<std::ofstream> stdoutLogStream;
   std::shared_ptr<std::ofstream> stderrLogStream;
   boost::optional<std::vector<std::string>> pauseCommand;
   boost::optional<std::vector<std::string>> resumeCommand;


### PR DESCRIPTION
This PR fixes wording in option names and variable names.