### PR TITLE
fix collision process at isolated obstacle point

### DIFF
--- a/official/course.cpp
+++ b/official/course.cpp
@@ -69,6 +69,9 @@ bool RaceCourse::collides(const LineSegment &m) const {
     int ny = y + ystep;
     for (int x = x1; x != x2; x += xstep) {
       int nx = x + xstep;
+      if (obstacle[y][x] && m.goesThru({x, y})) {
+	return true;
+      }
       if ((obstacle[y][x] && obstacle[ny][nx] &&
 	   LineSegment(Point(x, y), Point(nx, ny)).intersects(m)) ||
 	  (obstacle[ny][x] && obstacle[ny][nx] &&

--- a/player/raceState.cpp
+++ b/player/raceState.cpp
@@ -68,6 +68,9 @@ bool Course::obstacled(const Point &from, const Point &to) const {
     int ny = y + ystep;
     for (int x = x1; x != x2; x += xstep) {
       int nx = x + xstep;
+      if (obstacle[y][x] == ObstState::OBSTACLE && m.goesThru({x, y})) {
+	return true;
+      }
       if ((obstacle[y][x] == ObstState::OBSTACLE && obstacle[ny][nx] == ObstState::OBSTACLE &&
      LineSegment(Point(x, y), Point(nx, ny)).intersects(m)) ||
     (obstacle[ny][x] == ObstState::OBSTACLE && obstacle[ny][nx] == ObstState::OBSTACLE &&


### PR DESCRIPTION
fix #53 

現行の master branch（ f332cf1 ）
<img width="1067" alt="prev" src="https://user-images.githubusercontent.com/1694907/34386516-5f1a95b4-eb6c-11e7-99b7-243089e50000.png">

今回の commit 後
<img width="1066" alt="fixed" src="https://user-images.githubusercontent.com/1694907/34386515-5ed3cd5a-eb6c-11e7-8b51-40310ee289ca.png">

衝突判定関数において、
現行では点対の線分に対して交差判定を行っている
だけでしたが点だけに対しても通過判定を入れるようにしました。