### PR TITLE
[official] add missing data

### DIFF
--- a/official/course.cpp
+++ b/official/course.cpp
@@ -190,6 +190,7 @@ void RaceCourse::writeJson(ostream &out) {
   out << "{" << endl
       << "   \"filetype\": \"race course\"," << endl
       << "   \"width\": " << width  << ", \"length\": " << length << ',' << endl
+      << "   \"vision\": " << vision << ", \"thinkTime\" : " << thinkTime << ", \"stepLimit\" : " << stepLimit << ',' << endl
       << "   \"x0\": " << startX[0] << ", \"x1\": " << startX[1] << ',' << endl;
   out << "  \"obstacles\": [";
   int i = 0;


### PR DESCRIPTION
fix #56 

1行追加したのみです。
当たり前ではありますが viewer で問題なく表示できることを確認しました
そのため、 `"` の閉じ忘れなどフォーマットが崩れていることはなさそうです。