### PR TITLE
[viewer] fix view for narrow

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -284,11 +284,11 @@ function drawCourse() {
   var overviewWidth = overviewPitch*(course.width+1);
   // The rest of the space is used by the magnified display
   fieldWidth = svgWidth-overviewWidth-2*xmargin;
-  mag = fieldWidth/course.width;
+  mag = Math.min(64, Math.min(fieldWidth/course.width, svgHeight/11));
   field = document.createElementNS(ns, 'svg');
   field.setAttribute('height', svgHeight);
   field.setAttribute('width', fieldWidth);
-  field.setAttribute('x', 0);
+  field.setAttribute('x', Math.max(0, (fieldWidth - (course.width + 1) * mag) / 2 ));
   field.setAttribute('y', 0);
   // Draw the course on an SVG group "courseFig"
   gridDotRadius = mag*gridDotRadiusRatio;


### PR DESCRIPTION
fix #54 

差し当たって表示倍率の最大値を設定しました。
様々なケースを考えたとき、他にも問題は発生しますが
自分では対応できませんでした。

また、倍率が前回より小さくなるケース（例えば #54 ）で
コースの表示が左側になっているのは少し奇妙に思えたため、
与えられている幅の中で中央になるように調整しました。