### PR TITLE
fix display around goal time

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -178,7 +178,7 @@ function drawPlayer(p) {
     player.body.style.fill = failedFill;
     if (play) collisionSound.play();
     var coords = document.getElementById('position'+p);
-    coords.innerHTML = '(' + (px) + ',' + (py) + ')';
+    coords.innerHTML = 'Goal@'+raceLog['time'+p]+'(failed at '+step+')';
     player.icon.setAttribute('display', 'block');
     return;
   }
@@ -201,10 +201,14 @@ function drawPlayer(p) {
     player.body.style.fill = ok ? playerFill[player.id] : collisionFill;
     if (!ok) collisionSound.play();
     var coords = document.getElementById('position'+p);
-    if (py+vy >= course.length) {
+    if (py+vy >= course.length && ok) {
       coords.innerHTML = 'Goal@'+raceLog['time'+p];
-    } else if (py < course.length) {
+    } else if (step + 1 >= course.stepLimit) {
+      coords.innerHTML = 'Goal@'+raceLog['time'+p]+'(step limit over)';
+    } else if (ok) {
       coords.innerHTML = '(' + (px+vx) + ',' + (py+vy) + ')';
+    } else {
+      coords.innerHTML = '<del>(' + (px+vx) + ',' + (py+vy) + ')</del>(' + px + ',' + py + ')';
     }
     player.icon.setAttribute('display', 'block');
   } else {

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -178,7 +178,7 @@ function drawPlayer(p) {
     player.body.style.fill = failedFill;
     if (play) collisionSound.play();
     var coords = document.getElementById('position'+p);
-    coords.innerHTML = 'Goal@'+raceLog['time'+p]+'(failed at '+step+')';
+    coords.innerHTML = 'Goal@'+raceLog['time'+p]+'(failed at '+last.step+')';
     player.icon.setAttribute('display', 'block');
     return;
   }


### PR DESCRIPTION
fix #63 

現在の座標やゴールタイムを表示する部分を以下のように変更しました。

- コースアウト・衝突することなしにゴールラインに到達したらゴールタイムを表示
- 上記以外で最後のstepに達したら制限ステップ数切れとしてゴールタイムを表示
- 上記以外で失格となったら失格の旨を記載してゴールタイムを表示
- 上記以外でコースアウト・衝突をしていなかったら次状態の座標を表示（通常の表示）
- 上記以外では（すなわちコースアウト・衝突していたら）現在の座標と速度を足した座標に取り消し線を引き、次状態の座標を表示

#63 のケースでは以下のような表示なります。

<img width="488" alt="fix63_1" src="https://user-images.githubusercontent.com/1694907/34640621-9248583e-f339-11e7-8151-dba9586221ad.png">
<img width="485" alt="fix63_2" src="https://user-images.githubusercontent.com/1694907/34640622-9290d334-f339-11e7-8653-2340df45de4c.png">
<img width="485" alt="fix63_3" src="https://user-images.githubusercontent.com/1694907/34640623-92d85f06-f339-11e7-89e8-1fb994ad4f26.png">

失格の場合
<img width="485" alt="fix63_4" src="https://user-images.githubusercontent.com/1694907/34640624-932023a4-f339-11e7-8ad1-4764005fbe26.png">
となります。
