### PR TITLE
[official] fix stuck problems...

### DIFF
--- a/official/player.hpp
+++ b/official/player.hpp
@@ -33,9 +33,10 @@ public:
 };
 
 struct Player {
+  boost::process::group group;
+  std::unique_ptr<boost::process::child> child;
   std::unique_ptr<boost::process::opstream> toAI;
   std::unique_ptr<boost::process::ipstream> fromAI;
-  std::unique_ptr<boost::process::child> child;
   string name;
   Point position;
   IntVec velocity;


### PR DESCRIPTION
現在 backend で半永久的に続くゲームが行われていますが、
原因がゲームマネージャにありました。
申し訳ないです。

以下に示す2点の問題を見つけ、修正しました。

- `run_lookahead_java.sh` を用いて対戦させると起動するとゲームが終了しない
    - `boost::process::child::terminate` では親しか殺さず、子プロセスが死にませんでした。
    - こちらを参考に `boost::process::group::terminate` を利用するようにしました。
    - http://www.boost.org/doc/libs/1_64_0/doc/html/boost_process/tutorial.html#boost_process.tutorial.group
- 無限ループや stuck 状態に陥ったプレイヤーと対戦させるとゲームが進まなくなる
    - タイムアウトしたプレイヤーに対しても入力を受け付ける thread を join していました。
    - detach に変更しました。
    - 今まで現実的な時間で応答が返ってくるプレイヤーでしかタイムアウトのテストできていませんでした…。すみません…。
